### PR TITLE
fix id errors

### DIFF
--- a/lib/components/borderBox11/src/main.vue
+++ b/lib/components/borderBox11/src/main.vue
@@ -245,10 +245,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-11',
-      filterId: `border-box-11-filterId-${timestamp}`,
+      filterId: `border-box-11-filterId-${uuid}`,
 
       defaultColor: ['#8aaafb', '#1f33a2'],
 

--- a/lib/components/borderBox11/src/main.vue
+++ b/lib/components/borderBox11/src/main.vue
@@ -223,6 +223,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox11',
   mixins: [autoResize],
@@ -245,12 +247,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-11',
       filterId: `border-box-11-filterId-${uuid}`,

--- a/lib/components/borderBox12/src/main.vue
+++ b/lib/components/borderBox12/src/main.vue
@@ -113,10 +113,15 @@ export default {
     }
   },
   data () {
-    const timestamp = +new Date()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-12',
-      filterId: `borderr-box-12-filterId-${timestamp}`,
+      filterId: `borderr-box-12-filterId-${uuid}`,
 
       defaultColor: ['#2e6099', '#7ce7fd'],
 

--- a/lib/components/borderBox12/src/main.vue
+++ b/lib/components/borderBox12/src/main.vue
@@ -99,6 +99,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox12',
   mixins: [autoResize],
@@ -113,12 +115,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-12',
       filterId: `borderr-box-12-filterId-${uuid}`,

--- a/lib/components/borderBox13/src/main.vue
+++ b/lib/components/borderBox13/src/main.vue
@@ -47,6 +47,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox13',
   mixins: [autoResize],
@@ -61,12 +63,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-13',
 

--- a/lib/components/borderBox13/src/main.vue
+++ b/lib/components/borderBox13/src/main.vue
@@ -61,7 +61,12 @@ export default {
     }
   },
   data () {
-    const timestamp = +new Date()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-13',
 

--- a/lib/components/borderBox8/src/main.vue
+++ b/lib/components/borderBox8/src/main.vue
@@ -70,6 +70,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox8',
   mixins: [autoResize],
@@ -92,12 +94,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-8',
       path: `border-box-8-path-${uuid}`,

--- a/lib/components/borderBox8/src/main.vue
+++ b/lib/components/borderBox8/src/main.vue
@@ -92,12 +92,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-8',
-      path: `border-box-8-path-${timestamp}`,
-      gradient: `border-box-8-gradient-${timestamp}`,
-      mask: `border-box-8-mask-${timestamp}`,
+      path: `border-box-8-path-${uuid}`,
+      gradient: `border-box-8-gradient-${uuid}`,
+      mask: `border-box-8-mask-${uuid}`,
 
       defaultColor: ['#235fa7', '#4fd2dd'],
 

--- a/lib/components/borderBox9/src/main.vue
+++ b/lib/components/borderBox9/src/main.vue
@@ -144,12 +144,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-9',
 
-      gradientId: `border-box-9-gradient-${timestamp}`,
-      maskId: `border-box-9-mask-${timestamp}`,
+      gradientId: `border-box-9-gradient-${uuid}`,
+      maskId: `border-box-9-mask-${uuid}`,
 
       defaultColor: ['#11eefd', '#0078d2'],
 

--- a/lib/components/borderBox9/src/main.vue
+++ b/lib/components/borderBox9/src/main.vue
@@ -130,6 +130,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox9',
   mixins: [autoResize],
@@ -144,12 +146,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-9',
 

--- a/lib/components/charts/src/main.vue
+++ b/lib/components/charts/src/main.vue
@@ -19,10 +19,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      ref: `charts-container-${timestamp}`,
-      chartRef: `chart-${timestamp}`,
+      ref: `charts-container-${uuid}`,
+      chartRef: `chart-${uuid}`,
 
       chart: null
     }

--- a/lib/components/charts/src/main.vue
+++ b/lib/components/charts/src/main.vue
@@ -9,6 +9,8 @@ import autoResize from '../../../mixin/autoResize'
 
 import Charts from '@jiaminghi/charts'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvCharts',
   mixins: [autoResize],
@@ -19,12 +21,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: `charts-container-${uuid}`,
       chartRef: `chart-${uuid}`,

--- a/lib/components/decoration10/src/main.vue
+++ b/lib/components/decoration10/src/main.vue
@@ -162,17 +162,22 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-10',
 
-      animationId1: `d10ani1${timestamp}`,
-      animationId2: `d10ani2${timestamp}`,
-      animationId3: `d10ani3${timestamp}`,
-      animationId4: `d10ani4${timestamp}`,
-      animationId5: `d10ani5${timestamp}`,
-      animationId6: `d10ani6${timestamp}`,
-      animationId7: `d10ani7${timestamp}`,
+      animationId1: `d10ani1${uuid}`,
+      animationId2: `d10ani2${uuid}`,
+      animationId3: `d10ani3${uuid}`,
+      animationId4: `d10ani4${uuid}`,
+      animationId5: `d10ani5${uuid}`,
+      animationId6: `d10ani6${uuid}`,
+      animationId7: `d10ani7${uuid}`,
 
       defaultColor: ['#00c2ff', 'rgba(0, 194, 255, 0.3)'],
 

--- a/lib/components/decoration10/src/main.vue
+++ b/lib/components/decoration10/src/main.vue
@@ -152,6 +152,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvDecoration10',
   mixins: [autoResize],
@@ -162,12 +164,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'decoration-10',
 

--- a/lib/components/decoration11/src/main.vue
+++ b/lib/components/decoration11/src/main.vue
@@ -62,6 +62,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvDecoration11',
   mixins: [autoResize],
@@ -72,12 +74,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'decoration-11',
 

--- a/lib/components/decoration11/src/main.vue
+++ b/lib/components/decoration11/src/main.vue
@@ -72,7 +72,12 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-11',
 

--- a/lib/components/decoration9/src/main.vue
+++ b/lib/components/decoration9/src/main.vue
@@ -92,6 +92,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvDecoration9',
   mixins: [autoResize],
@@ -106,12 +108,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'decoration-9',
 

--- a/lib/components/decoration9/src/main.vue
+++ b/lib/components/decoration9/src/main.vue
@@ -106,11 +106,16 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-9',
 
-      polygonId: `decoration-9-polygon-${timestamp}`,
+      polygonId: `decoration-9-polygon-${uuid}`,
 
       svgWH: [100, 100],
 

--- a/lib/components/flylineChart/src/main.vue
+++ b/lib/components/flylineChart/src/main.vue
@@ -157,6 +157,8 @@ import { randomExtend, getPointDistance } from '../../../util/index'
 
 import autoResize from '../../../mixin/autoResize'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvFlylineChart',
   mixins: [autoResize],
@@ -171,12 +173,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'dv-flyline-chart',
       unique: Math.random(),

--- a/lib/components/flylineChart/src/main.vue
+++ b/lib/components/flylineChart/src/main.vue
@@ -171,14 +171,19 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'dv-flyline-chart',
       unique: Math.random(),
-      maskId: `flyline-mask-id-${timestamp}`,
-      maskCircleId: `mask-circle-id-${timestamp}`,
-      gradientId: `gradient-id-${timestamp}`,
-      gradient2Id: `gradient2-id-${timestamp}`,
+      maskId: `flyline-mask-id-${uuid}`,
+      maskCircleId: `mask-circle-id-${uuid}`,
+      gradientId: `gradient-id-${uuid}`,
+      gradient2Id: `gradient2-id-${uuid}`,
 
       defaultConfig: {
         /**

--- a/lib/components/flylineChartEnhanced/src/main.vue
+++ b/lib/components/flylineChartEnhanced/src/main.vue
@@ -173,12 +173,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'dv-flyline-chart-enhanced',
       unique: Math.random(),
-      flylineGradientId: `flyline-gradient-id-${timestamp}`,
-      haloGradientId: `halo-gradient-id-${timestamp}`,
+      flylineGradientId: `flyline-gradient-id-${uuid}`,
+      haloGradientId: `halo-gradient-id-${uuid}`,
       /**
        * @description Type Declaration
        * 

--- a/lib/components/flylineChartEnhanced/src/main.vue
+++ b/lib/components/flylineChartEnhanced/src/main.vue
@@ -159,6 +159,8 @@ import { randomExtend, getPointDistance } from '../../../util/index'
 
 import autoResize from '../../../mixin/autoResize'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvFlylineChartEnhanced',
   mixins: [autoResize],
@@ -173,12 +175,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'dv-flyline-chart-enhanced',
       unique: Math.random(),

--- a/lib/components/percentPond/src/main.vue
+++ b/lib/components/percentPond/src/main.vue
@@ -48,6 +48,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvPercentPond',
   props: {
@@ -57,12 +59,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       gradientId1: `percent-pond-gradientId1-${uuid}`,
       gradientId2: `percent-pond-gradientId2-${uuid}`,

--- a/lib/components/percentPond/src/main.vue
+++ b/lib/components/percentPond/src/main.vue
@@ -57,10 +57,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      gradientId1: `percent-pond-gradientId1-${timestamp}`,
-      gradientId2: `percent-pond-gradientId2-${timestamp}`,
+      gradientId1: `percent-pond-gradientId1-${uuid}`,
+      gradientId2: `percent-pond-gradientId2-${uuid}`,
 
       width: 0,
       height: 0,

--- a/lib/components/waterLevelPond/src/main.vue
+++ b/lib/components/waterLevelPond/src/main.vue
@@ -53,9 +53,14 @@ export default {
     default: () => ({})
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      gradientId: `water-level-pond-${timestamp}`,
+      gradientId: `water-level-pond-${uuid}`,
 
       defaultConfig: {
         /**

--- a/lib/components/waterLevelPond/src/main.vue
+++ b/lib/components/waterLevelPond/src/main.vue
@@ -46,6 +46,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import CRender from '@jiaminghi/c-render'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvWaterLevelPond',
   props: {
@@ -53,12 +55,7 @@ export default {
     default: () => ({})
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       gradientId: `water-level-pond-${uuid}`,
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -37,3 +37,13 @@ export function getPointDistance (pointOne, pointTwo) {
 
   return Math.sqrt(minusX * minusX + minusY * minusY)
 }
+
+export function getUuid() {
+  let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
+  return uuid;
+}

--- a/src/components/borderBox11/src/main.vue
+++ b/src/components/borderBox11/src/main.vue
@@ -245,10 +245,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-11',
-      filterId: `border-box-11-filterId-${timestamp}`,
+      filterId: `border-box-11-filterId-${uuid}`,
 
       defaultColor: ['#8aaafb', '#1f33a2'],
 

--- a/src/components/borderBox11/src/main.vue
+++ b/src/components/borderBox11/src/main.vue
@@ -223,6 +223,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox11',
   mixins: [autoResize],
@@ -245,12 +247,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-11',
       filterId: `border-box-11-filterId-${uuid}`,

--- a/src/components/borderBox12/src/main.vue
+++ b/src/components/borderBox12/src/main.vue
@@ -113,10 +113,15 @@ export default {
     }
   },
   data () {
-    const timestamp = +new Date()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-12',
-      filterId: `borderr-box-12-filterId-${timestamp}`,
+      filterId: `borderr-box-12-filterId-${uuid}`,
 
       defaultColor: ['#2e6099', '#7ce7fd'],
 

--- a/src/components/borderBox12/src/main.vue
+++ b/src/components/borderBox12/src/main.vue
@@ -99,6 +99,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox12',
   mixins: [autoResize],
@@ -113,12 +115,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-12',
       filterId: `borderr-box-12-filterId-${uuid}`,

--- a/src/components/borderBox13/src/main.vue
+++ b/src/components/borderBox13/src/main.vue
@@ -61,7 +61,12 @@ export default {
     }
   },
   data () {
-    const timestamp = +new Date()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-13',
 

--- a/src/components/borderBox13/src/main.vue
+++ b/src/components/borderBox13/src/main.vue
@@ -47,6 +47,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox13',
   mixins: [autoResize],
@@ -61,7 +63,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
+    const uuid = getUuid();
     const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
       var r = (d + Math.random()*16)%16 | 0;
       d = Math.floor(d/16);

--- a/src/components/borderBox8/src/main.vue
+++ b/src/components/borderBox8/src/main.vue
@@ -92,12 +92,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-8',
-      path: `border-box-8-path-${timestamp}`,
-      gradient: `border-box-8-gradient-${timestamp}`,
-      mask: `border-box-8-mask-${timestamp}`,
+      path: `border-box-8-path-${uuid}`,
+      gradient: `border-box-8-gradient-${uuid}`,
+      mask: `border-box-8-mask-${uuid}`,
 
       defaultColor: ['#235fa7', '#4fd2dd'],
 

--- a/src/components/borderBox8/src/main.vue
+++ b/src/components/borderBox8/src/main.vue
@@ -70,6 +70,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox8',
   mixins: [autoResize],
@@ -92,12 +94,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+   const uuid = getUuid();
     return {
       ref: 'border-box-8',
       path: `border-box-8-path-${uuid}`,

--- a/src/components/borderBox9/src/main.vue
+++ b/src/components/borderBox9/src/main.vue
@@ -144,12 +144,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'border-box-9',
 
-      gradientId: `border-box-9-gradient-${timestamp}`,
-      maskId: `border-box-9-mask-${timestamp}`,
+      gradientId: `border-box-9-gradient-${uuid}`,
+      maskId: `border-box-9-mask-${uuid}`,
 
       defaultColor: ['#11eefd', '#0078d2'],
 

--- a/src/components/borderBox9/src/main.vue
+++ b/src/components/borderBox9/src/main.vue
@@ -130,6 +130,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvBorderBox9',
   mixins: [autoResize],
@@ -144,12 +146,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'border-box-9',
 

--- a/src/components/charts/src/main.vue
+++ b/src/components/charts/src/main.vue
@@ -19,10 +19,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      ref: `charts-container-${timestamp}`,
-      chartRef: `chart-${timestamp}`,
+      ref: `charts-container-${uuid}`,
+      chartRef: `chart-${uuid}`,
 
       chart: null
     }

--- a/src/components/charts/src/main.vue
+++ b/src/components/charts/src/main.vue
@@ -9,6 +9,8 @@ import autoResize from '../../../mixin/autoResize'
 
 import Charts from '@jiaminghi/charts'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvCharts',
   mixins: [autoResize],
@@ -19,12 +21,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: `charts-container-${uuid}`,
       chartRef: `chart-${uuid}`,

--- a/src/components/decoration10/src/main.vue
+++ b/src/components/decoration10/src/main.vue
@@ -162,17 +162,22 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-10',
 
-      animationId1: `d10ani1${timestamp}`,
-      animationId2: `d10ani2${timestamp}`,
-      animationId3: `d10ani3${timestamp}`,
-      animationId4: `d10ani4${timestamp}`,
-      animationId5: `d10ani5${timestamp}`,
-      animationId6: `d10ani6${timestamp}`,
-      animationId7: `d10ani7${timestamp}`,
+      animationId1: `d10ani1${uuid}`,
+      animationId2: `d10ani2${uuid}`,
+      animationId3: `d10ani3${uuid}`,
+      animationId4: `d10ani4${uuid}`,
+      animationId5: `d10ani5${uuid}`,
+      animationId6: `d10ani6${uuid}`,
+      animationId7: `d10ani7${uuid}`,
 
       defaultColor: ['#00c2ff', 'rgba(0, 194, 255, 0.3)'],
 

--- a/src/components/decoration10/src/main.vue
+++ b/src/components/decoration10/src/main.vue
@@ -152,6 +152,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvDecoration10',
   mixins: [autoResize],
@@ -162,12 +164,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'decoration-10',
 

--- a/src/components/decoration11/src/main.vue
+++ b/src/components/decoration11/src/main.vue
@@ -62,6 +62,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvDecoration11',
   mixins: [autoResize],
@@ -72,12 +74,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'decoration-11',
 

--- a/src/components/decoration11/src/main.vue
+++ b/src/components/decoration11/src/main.vue
@@ -72,7 +72,12 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-11',
 

--- a/src/components/decoration9/src/main.vue
+++ b/src/components/decoration9/src/main.vue
@@ -92,6 +92,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import { fade } from '@jiaminghi/color'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvDecoration9',
   mixins: [autoResize],
@@ -106,12 +108,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'decoration-9',
 

--- a/src/components/decoration9/src/main.vue
+++ b/src/components/decoration9/src/main.vue
@@ -106,11 +106,16 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'decoration-9',
 
-      polygonId: `decoration-9-polygon-${timestamp}`,
+      polygonId: `decoration-9-polygon-${uuid}`,
 
       svgWH: [100, 100],
 

--- a/src/components/flylineChart/src/main.vue
+++ b/src/components/flylineChart/src/main.vue
@@ -157,6 +157,8 @@ import { randomExtend, getPointDistance } from '../../../util/index'
 
 import autoResize from '../../../mixin/autoResize'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvFlylineChart',
   mixins: [autoResize],
@@ -171,12 +173,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'dv-flyline-chart',
       unique: Math.random(),

--- a/src/components/flylineChart/src/main.vue
+++ b/src/components/flylineChart/src/main.vue
@@ -171,14 +171,19 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'dv-flyline-chart',
       unique: Math.random(),
-      maskId: `flyline-mask-id-${timestamp}`,
-      maskCircleId: `mask-circle-id-${timestamp}`,
-      gradientId: `gradient-id-${timestamp}`,
-      gradient2Id: `gradient2-id-${timestamp}`,
+      maskId: `flyline-mask-id-${uuid}`,
+      maskCircleId: `mask-circle-id-${uuid}`,
+      gradientId: `gradient-id-${uuid}`,
+      gradient2Id: `gradient2-id-${uuid}`,
 
       defaultConfig: {
         /**

--- a/src/components/flylineChartEnhanced/src/main.vue
+++ b/src/components/flylineChartEnhanced/src/main.vue
@@ -173,12 +173,17 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
       ref: 'dv-flyline-chart-enhanced',
       unique: Math.random(),
-      flylineGradientId: `flyline-gradient-id-${timestamp}`,
-      haloGradientId: `halo-gradient-id-${timestamp}`,
+      flylineGradientId: `flyline-gradient-id-${uuid}`,
+      haloGradientId: `halo-gradient-id-${uuid}`,
       /**
        * @description Type Declaration
        * 

--- a/src/components/flylineChartEnhanced/src/main.vue
+++ b/src/components/flylineChartEnhanced/src/main.vue
@@ -159,6 +159,8 @@ import { randomExtend, getPointDistance } from '../../../util/index'
 
 import autoResize from '../../../mixin/autoResize'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvFlylineChartEnhanced',
   mixins: [autoResize],
@@ -173,12 +175,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       ref: 'dv-flyline-chart-enhanced',
       unique: Math.random(),

--- a/src/components/percentPond/src/main.vue
+++ b/src/components/percentPond/src/main.vue
@@ -48,6 +48,8 @@ import { deepMerge } from '@jiaminghi/charts/lib/util/index'
 
 import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvPercentPond',
   props: {
@@ -57,12 +59,7 @@ export default {
     }
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       gradientId1: `percent-pond-gradientId1-${uuid}`,
       gradientId2: `percent-pond-gradientId2-${uuid}`,

--- a/src/components/percentPond/src/main.vue
+++ b/src/components/percentPond/src/main.vue
@@ -57,10 +57,15 @@ export default {
     }
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      gradientId1: `percent-pond-gradientId1-${timestamp}`,
-      gradientId2: `percent-pond-gradientId2-${timestamp}`,
+      gradientId1: `percent-pond-gradientId1-${uuid}`,
+      gradientId2: `percent-pond-gradientId2-${uuid}`,
 
       width: 0,
       height: 0,

--- a/src/components/waterLevelPond/src/main.vue
+++ b/src/components/waterLevelPond/src/main.vue
@@ -53,9 +53,14 @@ export default {
     default: () => ({})
   },
   data () {
-    const timestamp = Date.now()
+    let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
     return {
-      gradientId: `water-level-pond-${timestamp}`,
+      gradientId: `water-level-pond-${uuid}`,
 
       defaultConfig: {
         /**

--- a/src/components/waterLevelPond/src/main.vue
+++ b/src/components/waterLevelPond/src/main.vue
@@ -46,6 +46,8 @@ import { deepClone } from '@jiaminghi/c-render/lib/plugin/util'
 
 import CRender from '@jiaminghi/c-render'
 
+import { getUuid } from '../../../util'
+
 export default {
   name: 'DvWaterLevelPond',
   props: {
@@ -53,12 +55,7 @@ export default {
     default: () => ({})
   },
   data () {
-    let d = new Date().getTime();
-    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = (d + Math.random()*16)%16 | 0;
-      d = Math.floor(d/16);
-      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
-   });
+    const uuid = getUuid();
     return {
       gradientId: `water-level-pond-${uuid}`,
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -37,3 +37,13 @@ export function getPointDistance (pointOne, pointTwo) {
 
   return Math.sqrt(minusX * minusX + minusY * minusY)
 }
+
+export function getUuid() {
+  let d = new Date().getTime();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (d + Math.random()*16)%16 | 0;
+      d = Math.floor(d/16);
+      return (c=='x' ? r : (r&0x7|0x8)).toString(16);
+   });
+  return uuid;
+}


### PR DESCRIPTION
<!-- 将标签id从timestamp生成修改为uuid生成) -->

**该PR的类型是？**

- [Bug修复 ] 

**解决通过实践戳生成id导致页面border样式渲染有误的bug**

![2020-05-15_082718](https://user-images.githubusercontent.com/12559428/82113620-06960f00-978a-11ea-8c09-82ea984d9a9d.png)
通过时间戳生成id，当页面存在多个border的时候，比如我工作中，在一个页面中使用到5个大小不一的标签，有时会出现两个相同的id，如图所示，最后两个id相同，但是绘制的长宽度不同，因而导致页面渲染有误，因此改用uuid标志标签的id。

**该PR是否向下兼容?** (选择任一)

- [ 是] 

**是否在Chrome浏览器下进行过测试？**

- [ 是] 
