### PR TITLE
fix: 调用轮播表updateRows方法数据不更新

### DIFF
--- a/src/components/scrollBoard/src/main.vue
+++ b/src/components/scrollBoard/src/main.vue
@@ -351,7 +351,11 @@ export default {
 
       const rowLength = rowsData.length
 
-      if (rowNum >= rowLength) return
+      if (rowNum >= rowLength) {
+        // clear setTimeout and animationHandler
+        this.stopAnimation()
+        return
+      }
 
       if (start) {
         await new Promise(resolve => setTimeout(resolve, waitTime))
@@ -387,6 +391,8 @@ export default {
       if (!animationHandler) return
 
       clearTimeout(animationHandler)
+      // clear animationHandler
+      this.animationHandler = null
     },
     emitEvent (type, ri, ci, row, ceil) {
       const { ceils, rowIndex } = row


### PR DESCRIPTION
列表拥有数据后,置空数据列表此时动画定时停止,当再次调用`updateRows`进行数据更新时`animationHandler`不为空，以至于不会触发`animation`方法导致数据不更新

<!-- (将[ ]修改为[x]) -->

**该PR的类型是？** (至少选择一个)

- [x] Bug修复
- [ ] 新特性
- [ ] 新组件

**该PR是否向下兼容?** (选择任一)

- [ ] 是
- [ ] 否

如果为否，请描述冲突情况:

**涉及到的ISSUE:**

- [ ] 该PR如果涉及到某个ISSUE, 请在PR标题中描述出来 (例如. `fix #xxx[,#xxx]`, "xxx"为ISSUE序号)

**是否在Chrome浏览器下进行过测试？**

- [x] 是
- [ ] 否

如果这是一个**新特性**或**新组件**相关的PR，请提供如下信息

- [ ] 添加该特性或组件的原因
- [ ] 文档应该修改哪些信息
- [ ] 测试相关

提交**新特性**或**新组件**前请先发起一个相关的ISSUE请求

**其他信息:**
